### PR TITLE
Issue #1 - Disable werkzeug logging

### DIFF
--- a/app/flaskapp.py
+++ b/app/flaskapp.py
@@ -4,6 +4,13 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from flask import Flask
+import logging
 
 app = Flask(__name__)
 app.config.from_pyfile("config.py")
+
+# disable logs so we don't record IP addresses
+# note: we may have to turn this on in the future if we detect abuse.
+log = logging.getLogger('werkzeug')
+log.disabled = True
+app.logger.disabled = True


### PR DESCRIPTION
This way we don't log IP addresses of users who send in issues.

It may be that we have to enable this in the future if we detect abuse, and do some kind of log rotation + privacy policy work.

r? @karlcow 